### PR TITLE
Ensure RL evaluation logs metrics

### DIFF
--- a/src/reinforcement_learning.py
+++ b/src/reinforcement_learning.py
@@ -7,6 +7,7 @@ from tensordict import TensorDict, TensorDictBase
 
 import torch
 from torch_scatter import scatter_softmax, scatter_max
+import time
 
 from src.transportation_simulator import TransportationSimulator
 
@@ -175,11 +176,23 @@ class SimulatorEnv(EnvBase):
         self.rng.manual_seed(seed)
         return seed
 
-    def _reset(self, tensordict: TensorDictBase = None) -> TensorDictBase: 
+    def _reset(self, tensordict: TensorDictBase = None) -> TensorDictBase:
         """
         Reset the environment to its initial state.
         """
         self.simulator.reset()
+        # reset logs and timers so that evaluation metrics only reflect the new episode
+        self.simulator.inserting_time = 0
+        self.simulator.choice_time = 0
+        self.simulator.core_time = 0
+        self.simulator.withdraw_time = 0
+        self.simulator.leg_histogram_values = []
+        self.simulator.road_optimality_values = []
+        self.simulator.on_way_before = 0
+        self.simulator.done_before = 0
+        if hasattr(self.simulator.model_core.response_mpnn, "update_history"):
+            self.simulator.model_core.response_mpnn.update_history = []
+
         self.simulator.set_time(3600 * 6 - 60, 6)
         x, edge_attr, edge_index, agent_index = self.simulator.state()
         self.simulator.agent.reset()
@@ -205,17 +218,41 @@ class SimulatorEnv(EnvBase):
         node_origin = self.simulator.graph.edge_index[0][mask]
         node_destination = self.simulator.graph.edge_index[1][mask]
         h = self.simulator.h
+
+        # Apply action (choice phase)
+        b = time.time()
         self.simulator.graph.x[node_origin, h.SELECTED_ROAD] = node_destination.to(torch.float)
+        e = time.time()
+        self.simulator.choice_time += e - b
+
+        # Core model
+        b = e
         self.simulator.graph = self.simulator.model_core(self.simulator.graph)
+        e = time.time()
+        self.simulator.core_time += e - b
+
+        # Withdraw agents
+        b = e
         last_people = self.simulator.graph.x[:, h.HEAD_FIFO].to(torch.long)
         self.simulator.graph.x = self.simulator.agent.withdraw_agent_from_network(self.simulator.graph.x, h)
+        e = time.time()
+        self.simulator.withdraw_time += e - b
+
+        # Insert agents
+        b = e
         self.simulator.graph.x = self.simulator.agent.insert_agent_into_network(self.simulator.graph.x, h)
+        e = time.time()
+        self.simulator.inserting_time += e - b
+
         new_state = self.simulator.graph.x[:, h.NUMBER_OF_AGENT]
         reward = torch.zeros(1, dtype=torch.float32, device=self.device)
         # Compute reward
         arrived = self.simulator.agent.agent_features[last_people, self.simulator.agent.DONE].to(torch.bool)
         rewardable_people = last_people[arrived]
-        time_travel = self.simulator.agent.agent_features[rewardable_people, self.simulator.agent.ARRIVAL_TIME] - self.simulator.agent.agent_features[rewardable_people, self.simulator.agent.DEPARTURE_TIME]
+        time_travel = (
+            self.simulator.agent.agent_features[rewardable_people, self.simulator.agent.ARRIVAL_TIME]
+            - self.simulator.agent.agent_features[rewardable_people, self.simulator.agent.DEPARTURE_TIME]
+        )
         individual_reward = 0 + torch.sum(100 * 600 / time_travel)
         reward = - torch.sum(self.simulator.graph.x[:, h.NUMBER_OF_AGENT])
         reward = torch.sum(reward).flatten()
@@ -228,10 +265,29 @@ class SimulatorEnv(EnvBase):
             done = torch.tensor(True)
         else:
             done = torch.tensor(False)
+
+        # Log histogram and optimality metrics
+        value_on_way = torch.sum(self.simulator.agent.agent_features[:, self.simulator.agent.ON_WAY])
+        value_done = torch.sum(self.simulator.agent.agent_features[:, self.simulator.agent.DONE])
+        self.simulator.leg_histogram_values.append([
+            value_on_way - self.simulator.on_way_before + value_done - self.simulator.done_before,
+            value_done - self.simulator.done_before,
+            value_on_way,
+            self.simulator.time,
+        ])
+        self.simulator.on_way_before = value_on_way
+        self.simulator.done_before = value_done
+        self.simulator.road_optimality_values.append(
+            (
+                self.simulator.time,
+                self.simulator.model_core.direction_mpnn.road_optimality_data["delta_travel_time"].cpu(),
+            )
+        )
+
         # Compute the next state
         node_features, edge_features, edge_index, agent_index = self.simulator.state()
         terminated = done
-        
+
         return TensorDict({
             "node_features": node_features,
             "edge_features": edge_features,

--- a/tests/rl_metrics_test.py
+++ b/tests/rl_metrics_test.py
@@ -1,0 +1,55 @@
+import torch
+from tensordict import TensorDict
+from src.reinforcement_learning import SimulatorEnv
+from src.transportation_simulator import TransportationSimulator
+from src.agents.base import Agents
+
+
+def test_rl_training_and_evaluation_collect_metrics(monkeypatch, simple_network_file):
+    # Patch network loading to use a simple test network
+    def fake_load_network(self, scenario):
+        self.config_network(simple_network_file)
+    monkeypatch.setattr(TransportationSimulator, "load_network", fake_load_network)
+    # Simplify agent operations
+    monkeypatch.setattr(Agents, "reset", lambda self: None)
+    monkeypatch.setattr(Agents, "withdraw_agent_from_network", lambda self, x, h: x)
+    monkeypatch.setattr(Agents, "insert_agent_into_network", lambda self, x, h: x)
+
+    env = SimulatorEnv(device="cpu", timestep_size=1, start_time=0, scenario="dummy")
+    eval_env = SimulatorEnv(device="cpu", timestep_size=1, start_time=0, scenario="dummy")
+
+    for e in (env, eval_env):
+        e.simulator.agent.agent_features = torch.zeros((1, 9))
+        e.simulator.agent.set_time(e.simulator.time)
+
+    num_edges = env.simulator.graph.edge_index.size(1)
+    param = torch.nn.Parameter(torch.zeros(num_edges))
+    optim = torch.optim.SGD([param], lr=0.1)
+
+    # --- Training loop (2 steps) ---
+    env._reset()
+    for _ in range(2):
+        action = (param > 0).to(torch.bool).float()
+        td = TensorDict({"action": action}, batch_size=[])
+        env._step(td)
+        loss = param.sum()
+        loss.backward()
+        optim.step()
+        optim.zero_grad()
+
+    assert env.simulator.time > 0
+    assert torch.any(param != 0)  # parameter updated
+
+    # --- Evaluation rollout ---
+    eval_env._reset()
+    for _ in range(2):
+        action = (param > 0).to(torch.bool).float()
+        td = TensorDict({"action": action}, batch_size=[])
+        eval_env._step(td)
+
+    assert eval_env.simulator.leg_histogram_values
+    assert eval_env.simulator.road_optimality_values
+    total_time = (
+        eval_env.simulator.inserting_time + eval_env.simulator.core_time + eval_env.simulator.withdraw_time
+    )
+    assert total_time > 0


### PR DESCRIPTION
## Summary
- Reset simulator logs and timers when RL environment resets
- Record computation time and histogram/optimality data during RL steps
- Add regression test confirming RL training step updates parameters and evaluation collects metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896d49ef3e08329b639438bfe16f089