### PR TITLE
Remove 7h cutoff in RL evaluation

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -52,6 +52,7 @@ class Runner:
                 device=str(self.device),
                 timestep_size=self.args.timestep_size,
                 start_time=self.args.start_end_time[0],
+                end_time=self.args.start_end_time[1],
                 scenario=self.args.scenario,
             )
 
@@ -108,6 +109,7 @@ class Runner:
             device=str(self.device),
             timestep_size=self.args.timestep_size,
             start_time=self.args.start_end_time[0],
+            end_time=self.args.start_end_time[1],
             scenario=self.args.scenario,
         )
         eval_env.simulator.agent = self.policy_net


### PR DESCRIPTION
## Summary
- Allow SimulatorEnv to run until a configurable end_time instead of stopping at 7h
- Pass scenario end time from Runner to SimulatorEnv for both training and evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e3dc69b4832982791fbd00ae8fd6