### PR TITLE
Optimize MPNN modules with torch.compile

### DIFF
--- a/src/response_mpnn.py
+++ b/src/response_mpnn.py
@@ -2,6 +2,8 @@ from torch_geometric.nn import MessagePassing
 from src.feature_helpers import FeatureHelpers
 import torch
 
+
+@torch.compile
 class ResponseMPNN(MessagePassing):
     """
     MPNN that communicate which agent has been accepted previously.


### PR DESCRIPTION
## Summary
- Decorate DirectionMPNN and ResponseMPNN with `torch.compile` for ahead-of-time optimization
- Wrap scatter operations in DirectionMPNN with dynamo-disabled helpers for compatibility

## Testing
- `pytest tests/direction_mpnn_test.py tests/response_mpnn_test.py -q`
- `pytest tests -q`
- `python - <<'PY'
import time, torch
from src.direction_mpnn import DirectionMPNN
from src.response_mpnn import ResponseMPNN
from torch_geometric.data import Data
Nmax = 100
feature_dim = 3*Nmax + 7

def build_node_feature(agent_pos, agent_t_arrival, agent_pos_at_arrival,
                        max_number_agent, number_agent, free_flow_time,
                        length_of_road, max_flow, selected_road, id_road):
    f = torch.zeros(feature_dim)
    f[0:Nmax] = agent_pos.clone().detach().float()
    f[Nmax:2*Nmax] = agent_t_arrival.clone().detach().float()
    f[2*Nmax:3*Nmax] = agent_pos_at_arrival.clone().detach().float()
    f[3*Nmax + 0] = max_number_agent
    f[3*Nmax + 1] = number_agent
    f[3*Nmax + 2] = free_flow_time
    f[3*Nmax + 3] = length_of_road
    f[3*Nmax + 4] = max_flow
    f[3*Nmax + 5] = selected_road
    f[3*Nmax + 6] = id_road
    return f
x = torch.stack([
    build_node_feature(torch.zeros(Nmax), torch.zeros(Nmax), torch.zeros(Nmax), 2, 1, 3.0, 100.0, 10.0, 1, 0),
    build_node_feature(torch.zeros(Nmax), torch.zeros(Nmax), torch.zeros(Nmax), 2, 1, 1.0, 100.0, 10.0, 2, 1),
    build_node_feature(torch.zeros(Nmax), torch.zeros(Nmax), torch.zeros(Nmax), 2, 2, 1.0, 100.0, 10.0, 0, 2),
])
x[0,0]=1.0; x[1,0]=2.0; x[2,0]=3.0; x[2,1]=4.0; x[2,2*Nmax + 1]=1.0
edge_index = torch.tensor([[0,1,2],[1,2,0]], dtype=torch.long)
edge_attr = torch.rand(edge_index.size(1),1)
data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr)
mpnn = DirectionMPNN(); rg = ResponseMPNN()
for _ in range(3): mpnn(data.x, data.edge_index, data.edge_attr); rg(data.x, data.edge_index, data.edge_attr)
start=time.time();
for _ in range(100): mpnn(data.x, data.edge_index, data.edge_attr);
end=time.time(); print('DirectionMPNN time', end-start);
start=time.time();
for _ in range(100): rg(data.x, data.edge_index, data.edge_attr);
end=time.time(); print('ResponseMPNN time', end-start);
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a6197083b4832985ac5064a74aa61c