### PR TITLE
Add flag to toggle torch.compile for MPNNs

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,11 @@ def main(argv=None):
         action="store_true",
         help="Profile the simulation loop with cProfile",
     )
+    parser.add_argument(
+        "--torch-compile",
+        action="store_true",
+        help="Enable torch.compile for MPNN models",
+    )
     args = parser.parse_args(argv)
 
     runner = Runner(RunnerArgs(**vars(args)))

--- a/src/direction_mpnn.py
+++ b/src/direction_mpnn.py
@@ -16,7 +16,6 @@ def _scatter_max(*args, **kwargs):
     return scatter_max(*args, **kwargs)
 
 
-@torch.compile
 class DirectionMPNN(MessagePassing, FeatureHelpers):
     """
     MPNN that communicate the next direction of agents to downstream nodes

--- a/src/reinforcement_learning.py
+++ b/src/reinforcement_learning.py
@@ -104,9 +104,16 @@ class SimulatorEnv(EnvBase):
     A custom environment for reinforcement learning based on the simpson simulator.
     """
 
-    def __init__(self, device: str = 'cpu', timestep_size: int = 1, start_time: int = 0, scenario: str = "Easy"):
+    def __init__(
+        self,
+        device: str = 'cpu',
+        timestep_size: int = 1,
+        start_time: int = 0,
+        scenario: str = "Easy",
+        torch_compile: bool = False,
+    ):
         super().__init__(device=device)
-        self.simulator = TransportationSimulator(device=device)
+        self.simulator = TransportationSimulator(device=device, torch_compile=torch_compile)
         self.simulator.load_network(scenario=scenario)
         self.simulator.config_parameters(timestep_size=timestep_size, start_time=start_time)
         self.to(device)

--- a/src/response_mpnn.py
+++ b/src/response_mpnn.py
@@ -3,7 +3,6 @@ from src.feature_helpers import FeatureHelpers
 import torch
 
 
-@torch.compile
 class ResponseMPNN(MessagePassing):
     """
     MPNN that communicate which agent has been accepted previously.

--- a/src/runner.py
+++ b/src/runner.py
@@ -19,6 +19,7 @@ class RunnerArgs:
     device: str = "cpu"
     output_dir: str = "runs"
     profile: bool = False
+    torch_compile: bool = False
 
 
 class Runner:
@@ -32,7 +33,7 @@ class Runner:
     def setup(self):
         # --- Initialize the simulator and agent based on the algorithm ---
         if self.args.algo in {"dijkstra", "random"}:
-            self.simulator = TransportationSimulator(self.device)
+            self.simulator = TransportationSimulator(self.device, torch_compile=self.args.torch_compile)
             if self.args.algo == "dijkstra":
                 self.agent = DijkstraAgents(self.device)
             else:
@@ -54,6 +55,7 @@ class Runner:
                 timestep_size=self.args.timestep_size,
                 start_time=self.args.start_end_time[0],
                 scenario=self.args.scenario,
+                torch_compile=self.args.torch_compile,
             )
 
             edge_index = self.env.simulator.graph.edge_index
@@ -110,6 +112,7 @@ class Runner:
             timestep_size=self.args.timestep_size,
             start_time=self.args.start_end_time[0],
             scenario=self.args.scenario,
+            torch_compile=self.args.torch_compile,
         )
         eval_env.simulator.agent = self.policy_net
 

--- a/src/simulation_core_model.py
+++ b/src/simulation_core_model.py
@@ -6,6 +6,7 @@ from torch_geometric.data import Data
 from src.feature_helpers import FeatureHelpers # A Supprimer
 import torch
 
+
 class SimulationCoreModel(nn.Module):
     """
     Simulation Core that captures road dynamics but does not handle insertion or withdrawal agent.
@@ -27,10 +28,13 @@ class SimulationCoreModel(nn.Module):
         The maximal number of agents in a queue.
     """
 
-    def __init__(self, Nmax: int, device: str, time: int):
+    def __init__(self, Nmax: int, device: str, time: int, torch_compile: bool = False):
         super(SimulationCoreModel, self).__init__()
         self.direction_mpnn = DirectionMPNN(Nmax=Nmax, time=time).to(device)
         self.response_mpnn = ResponseMPNN(Nmax=Nmax, time=time).to(device)
+        if torch_compile:
+            self.direction_mpnn = torch.compile(self.direction_mpnn)
+            self.response_mpnn = torch.compile(self.response_mpnn)
         self.time = time
         self.Nmax = Nmax
 

--- a/src/transportation_simulator.py
+++ b/src/transportation_simulator.py
@@ -31,10 +31,11 @@ class TransportationSimulator:
         Timestep for the simulation
     """
 
-    def __init__(self, device: str):
+    def __init__(self, device: str, torch_compile: bool = False):
         self.model_core = None
         self.agent = Agents(device)
         self.device = device
+        self.torch_compile = torch_compile
 
         # The feature are the graph transportation network
         self.graph = None
@@ -267,8 +268,8 @@ class TransportationSimulator:
         
     def configure_core(self):
         """
-        Configure the simulation core for handle road simulation thanks to the 
-        
+        Configure the simulation core for handle road simulation thanks to the
+
 
         Parameters
         ----------
@@ -276,7 +277,9 @@ class TransportationSimulator:
             Relative or absolute path which contains the MATSim configuration
         ----------
         """
-        self.model_core = SimulationCoreModel(self.Nmax, self.device, self.time)
+        self.model_core = SimulationCoreModel(
+            self.Nmax, self.device, self.time, torch_compile=self.torch_compile
+        )
     
     def set_time(self, time):
         """


### PR DESCRIPTION
## Summary
- Add `--torch-compile` CLI flag to enable optional JIT compilation
- Remove default `@torch.compile` decorators from `DirectionMPNN` and `ResponseMPNN`
- Propagate flag through runner and simulator to compile models only when requested

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61dd2d58083299a004d18ed634caa