### PR TITLE
Add Wardrop gap metric

### DIFF
--- a/src/reinforcement_learning.py
+++ b/src/reinforcement_learning.py
@@ -293,6 +293,9 @@ class SimulatorEnv(EnvBase):
             )
         )
 
+        gap = self.simulator.compute_wardrop_gap()
+        self.simulator.wardrop_gap_values.append((self.simulator.time, gap))
+
         # Compute the next state
         node_features, edge_features, edge_index, agent_index = self.simulator.state()
         terminated = done

--- a/tests/agents_test.py
+++ b/tests/agents_test.py
@@ -26,6 +26,7 @@ class TestAgent:
             num_roads=1,
             adj_matrix=adj,
         )
+        graph.congestion_constant = torch.ones(x.size(0))
         agents.time = 0
         graph.x = agents.insert_agent_into_network(graph, h)
         assert graph.x[0, h.NUMBER_OF_AGENT] == 2
@@ -66,6 +67,7 @@ class TestAgent:
             num_roads=1,
             adj_matrix=adj,
         )
+        graph.congestion_constant = torch.ones(x.size(0))
         agent.time = 0
         graph.x = agent.insert_agent_into_network(graph, h)
         assert graph.x[0, h.NUMBER_OF_AGENT] == 2

--- a/tests/rl_metrics_test.py
+++ b/tests/rl_metrics_test.py
@@ -51,6 +51,7 @@ def test_rl_training_and_evaluation_collect_metrics(monkeypatch, simple_network_
 
     assert eval_env.simulator.leg_histogram_values
     assert eval_env.simulator.road_optimality_values
+    assert eval_env.simulator.wardrop_gap_values
     total_time = (
         eval_env.simulator.inserting_time + eval_env.simulator.core_time + eval_env.simulator.withdraw_time
     )

--- a/tests/transportation_simulator_test.py
+++ b/tests/transportation_simulator_test.py
@@ -23,3 +23,4 @@ class TestTransportationSimulator:
             steps += 1
         assert simulator.time == start_time + steps * simulator.timestep
         assert simulator.agent.agent_features[1, simulator.agent.DONE] == 1
+        assert simulator.wardrop_gap_values


### PR DESCRIPTION
## Summary
- track Wardrop gap evolution during simulation
- compute gap via shortest-path comparison of chosen vs optimal costs
- record metric after each simulation step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7783968ec8329a9632e0f26d11ee2