### PR TITLE
Add optional W&B logging flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,6 +29,11 @@ def main(argv=None):
         action="store_true",
         help="Enable torch.compile for MPNN models",
     )
+    parser.add_argument(
+        "--wandb",
+        action="store_true",
+        help="Enable logging to Weights & Biases",
+    )
     args = parser.parse_args(argv)
 
     runner = Runner(RunnerArgs(**vars(args)))

--- a/src/runner.py
+++ b/src/runner.py
@@ -21,6 +21,7 @@ class RunnerArgs:
     output_dir: str = "runs"
     profile: bool = False
     torch_compile: bool = False
+    wandb: bool = False
 
 
 class Runner:
@@ -100,9 +101,9 @@ class Runner:
                 raise RuntimeError("Training is only supported in 'train' mode")
 
             from tqdm import tqdm
-            import wandb
-
-            wandb.init(project="tarl-simulator", name="contextual-bandit")
+            if self.args.wandb:
+                import wandb
+                wandb.init(project="tarl-simulator", name="contextual-bandit")
 
             n_timesteps = (
                 self.args.start_end_time[1] - self.args.start_end_time[0]
@@ -144,10 +145,12 @@ class Runner:
                 )
                 rmse = torch.sqrt(torch.mean((sim - exp) ** 2)).item()
                 print(f"{'RMSE demand:':25} {rmse:10.4f}")
-                wandb.log({"rmse_demand": rmse, "epoch": epoch + 1})
+                if self.args.wandb:
+                    wandb.log({"rmse_demand": rmse, "epoch": epoch + 1})
                 pbar.set_postfix(rmse=rmse)
 
-            wandb.finish()
+            if self.args.wandb:
+                wandb.finish()
             return
 
         if not (self.args.algo == "mpnn+ppo" and self.args.mode == "train"):

--- a/tests/main_cli_test.py
+++ b/tests/main_cli_test.py
@@ -36,3 +36,19 @@ def test_mpnn_eval(monkeypatch):
     monkeypatch.setattr(Runner, "eval", fake_eval)
     main(["--algo", "mpnn", "--mode", "eval"])
     assert calls == ["setup", "eval"]
+
+
+def test_wandb_flag(monkeypatch):
+    captured = {}
+
+    def fake_init(self, args):
+        captured["wandb"] = args.wandb
+        self.args = args
+
+    monkeypatch.setattr(Runner, "__init__", fake_init)
+    monkeypatch.setattr(Runner, "setup", lambda self: None)
+    monkeypatch.setattr(Runner, "eval", lambda self: None)
+
+    main(["--algo", "dijkstra", "--mode", "eval", "--wandb"])
+
+    assert captured["wandb"] is True


### PR DESCRIPTION
## Summary
- add `--wandb` CLI flag to enable Weights & Biases logging
- pass wandb flag via `RunnerArgs` and conditionally log during training
- cover new flag with a CLI test

## Testing
- `python -m pytest -q`
- `flake8 main.py src tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e1da80c483298fdf96004b66ab98